### PR TITLE
fix endpoint url

### DIFF
--- a/admin/partials/settings-functions.php
+++ b/admin/partials/settings-functions.php
@@ -34,7 +34,11 @@ class wp_rest_api_controller_Settings {
 
 		$post_types = $this->get_registered_post_types();
 
-		$this->rest_endpoint_base = esc_url( site_url( '/wp-json/wp/v2/' ) );
+        /**
+         * @link https://developer.wordpress.org/reference/functions/get_rest_url/
+         * @return Full URL to the endpoint.
+         */
+		$this->rest_endpoint_base = esc_url( get_rest_url( null, '/wp/v2/' ) );
 
 		add_settings_section(
 			'wp_rest_api_controller_setting_section',

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yikesinc, eherman24, liljimmi, yikesitskevin
 Tags: rest, api, endpoint, controller, meta, data, meta_data, toggle, endpoints, rest_base, rest_name, REST API, yikes, inc
 Requires at least: WordPress 4.7
 Tested up to: 4.7.2
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -71,6 +71,9 @@ A repeating postmeta field is one where there are multiple database entries for 
 1. WP REST API Controller settings page.
 
 == Changelog ==
+
+= WP REST API Controller v1.4.2 - February 2rd, 2019 =
+* Update rest_endpoint_base static string to wp-core get_rest_url() flexible url
 
 = WP REST API Controller v1.4.1 - February 23rd, 2017 =
 * A new filter has been added: `wp_rest_api_controller_retrieve_meta_single`. This controls the `$single` argument for the `get_post_meta()` function. Please note: if you want to see all of the values for repeating meta key fields (i.e. multiple entries in the postmeta table corresponding to the same key) you *need to use this filter* and return false. If you don't you will only retrieve the first value. For more information, see the FAQ "How do I retrieve repeating postmeta fields."

--- a/wp-rest-api-controller.php
+++ b/wp-rest-api-controller.php
@@ -3,7 +3,7 @@
  * 		Plugin Name:       WP REST API Controller
  * 		Plugin URI:        https://www.yikesplugins.com
  * 		Description:       WP REST API Controller enables a UI to toggle endpoints in the REST API.
- * 		Version:           1.4.1
+ * 		Version:           1.4.2
  * 		Author:            YIKES, Inc., Evan Herman, yikesitskevin
  * 		Author URI:        https://www.yikesinc.com
  * 		License:           GPL-3.0+


### PR DESCRIPTION
In case someone uses a custom prefix for wp-json
like this
`add_filter( 'rest_url_prefix', function() {  return "api"; } );`

the path looks like **example.com/api/wp/v2/**

I made a small update for setting page.