### PR TITLE
Fix settings notice, localize clear transient tooltip.

### DIFF
--- a/.dev/tests/php/test-wp-rest-api-controller-admin.php
+++ b/.dev/tests/php/test-wp-rest-api-controller-admin.php
@@ -223,6 +223,7 @@ class Test_WP_REST_API_Controller_Admin extends WP_UnitTestCase {
 	 */
 	function testSettingsUpdatedAdminNotice() {
 
+		$_GET['page'] = 'wp-rest-api-controller-settings';
 		$_GET['settings-updated'] = true;
 
 		$this->expectOutputRegex( '/<div class="notice notice-success"><p>Settings have been successfully updated.<\/p><\/div>/' );
@@ -238,6 +239,7 @@ class Test_WP_REST_API_Controller_Admin extends WP_UnitTestCase {
 	 */
 	function testRESTAPICacheClearedAdminNotice() {
 
+		$_GET['page'] = 'wp-rest-api-controller-settings';
 		$_GET['wp-rest-api-cache-cleared'] = true;
 
 		$this->expectOutputRegex( '/<div class="notice notice-success"><p>The WP REST API Controller cache has been cleared, and the post type and meta data lists below have been updated.<\/p><\/div>/' );

--- a/admin/class-wp-rest-api-controller-admin.php
+++ b/admin/class-wp-rest-api-controller-admin.php
@@ -116,6 +116,16 @@ if ( ! class_exists( 'WP_REST_API_Controller_Admin' ) ) {
 		 */
 		public function wp_rest_api_controller_admin_notices() {
 
+			if ( ! isset( $_GET['page'] ) ) {
+				return;
+			}
+
+			$page = filter_var( $_GET['page'], FILTER_SANITIZE_STRING );
+
+			if ( 'wp-rest-api-controller-settings' !== $page ) {
+				return;
+			}
+
 			if ( isset( $_GET['settings-updated'] ) ) {
 				$settings_updated = filter_var( $_GET['settings-updated'], FILTER_VALIDATE_BOOLEAN );
 

--- a/admin/partials/settings-page.php
+++ b/admin/partials/settings-page.php
@@ -23,8 +23,10 @@
 		submit_button( __( 'Save Settings', 'wp-rest-api-controller' ), 'primary', 'save-wp-rest-api-controller-settings', false );
 
 		printf(
-			'<a href="%1$s" class="button tipso tipso_style" data-tipso-title="Delete REST API Cache" data-tipso="Clear the WP REST API Cache stored in this plugin. If you recently registered a new post type, or assigned new meta data to a post - click this to update the lists above.">%2$s</a>',
+			'<a href="%1$s" class="button tipso tipso_style" data-tipso-title="%2$s" data-tipso="%3$s">%4$s</a>',
 			esc_url( add_query_arg( '_wpnonce', wp_create_nonce( 'clear-api-cache' ), admin_url( 'tools.php?page=wp-rest-api-controller-settings' ) ) ),
+			esc_attr__( 'Delete REST API Cache', 'wp-rest-api-controller' ),
+			esc_attr__( 'Clear the WP REST API Cache stored in this plugin. If you recently registered a new post type, or assigned new meta data to a post - click this to update the lists above.', 'wp-rest-api-controller' ),
 			esc_html__( 'Clear Cache', 'wp-rest-api-controller' )
 		);
 

--- a/languages/wp-rest-api-controller.pot
+++ b/languages/wp-rest-api-controller.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-07-02T14:08:21+00:00\n"
+"POT-Creation-Date: 2022-07-03T11:40:51+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: wp-rest-api-controller\n"
@@ -147,5 +147,13 @@ msgid "Save Settings"
 msgstr ""
 
 #: admin/partials/settings-page.php:28
+msgid "Delete REST API Cache"
+msgstr ""
+
+#: admin/partials/settings-page.php:29
+msgid "Clear the WP REST API Cache stored in this plugin. If you recently registered a new post type, or assigned new meta data to a post - click this to update the lists above."
+msgstr ""
+
+#: admin/partials/settings-page.php:30
 msgid "Clear Cache"
 msgstr ""


### PR DESCRIPTION
- Fix settings updated and clear cache admin notices. These were showing up in other plugins when settings were saved.
- The clear transient tooltip wasn't properly localized and the translations weren't present.
- Regenerated the .pot file with the new clear transient tooltip strings.