### PR TITLE
Fix includes when generating .pot file

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -20,3 +20,4 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SLUG: wp-rest-api-controller
+          IGNORE_OTHER_FILES: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,16 @@ module.exports = function( grunt ) {
 					},
 				],
 			},
+			readme_md: {
+				overwrite: true,
+				replacements: [
+					{
+						from: /pluginVersion=&message=v[\w.+-]+&/,
+						to: 'pluginVersion=&message=v<%= pkg.version %>&'
+					}
+				],
+				src: [ 'readme.md' ]
+			},
 			tests: {
 				src: '.dev/tests/phpunit/**/*.php',
 				overwrite: true,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"lint:js": "yarn eslint 'admin/js/*.js'",
 		"lint:css": "yarn stylelint admin/css/*.css",
 		"phpcs": "./vendor/bin/phpcs .",
-		"generate-pot": "wp i18n make-pot . languages/wp-rest-api-controller.pot --domain=wp-rest-api-controller --include=wp-rest-api-controller.php,admin/**/*.php --subtract-and-merge",
+		"generate-pot": "wp i18n make-pot . languages/wp-rest-api-controller.pot --domain=wp-rest-api-controller --include=wp-rest-api-controller.php,admin/*.php,admin/partials/*.php --subtract-and-merge",
 		"watch": "npm-watch",
 		"prepare": "husky install",
 		"version": "grunt version && yarn generate-pot && git add -A .",


### PR DESCRIPTION
- Fix update readme workflow. Add `IGNORE_OTHER_FILES` to the environment variables so only the readme file and assets are pushed.
- Ensure all strings in the plugin are included in the .pot file.
- Regenerate .pot file.
- Add readme_md to replace gruntfile task to keep readme.md version badge up to date.