### PR TITLE
Fix empty rest_base value

### DIFF
--- a/wp-rest-api-controller.php
+++ b/wp-rest-api-controller.php
@@ -285,7 +285,7 @@ if ( ! class_exists( 'WP_REST_API_Controller' ) ) {
 
 			$post_type_obj = get_post_type_object( $post_type_slug );
 
-			$rest_base = ( isset( $post_type_options['rest_base'] ) && ! empty( $post_type_options['rest_base'] ) ) ? $post_type_options['rest_base'] : $post_type_obj->rest_base;
+			$rest_base = ( isset( $post_type_options['rest_base'] ) && ! empty( $post_type_options['rest_base'] ) ) ? $post_type_options['rest_base'] : ( ( isset( $post_type_obj->rest_base ) && ! empty( $post_type_obj->rest_base ) ) ? $post_type_obj->rest_base : $post_type_slug );
 
 			return apply_filters( 'wp_rest_api_controller_rest_base', $rest_base, $post_type_slug );
 


### PR DESCRIPTION
If a post type is registered with no rest_base value, the API endpoint is empty on the settings page (eg: /wp-json/wp/v2/). This PR ensures the API endpoint rest_base always exists. If one is not registered with the post type, then the post type slug is used as a fallback.